### PR TITLE
feat: make action faster

### DIFF
--- a/.github/workflows/wom-to-avif.yml
+++ b/.github/workflows/wom-to-avif.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          export DEBIAN_FRONTEND=noninteractive
           sudo apt update
           sudo apt -y install plasma-wallpaper-dynamic kimageformat-plugins
 

--- a/.github/workflows/wom-to-avif.yml
+++ b/.github/workflows/wom-to-avif.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    container: docker.io/library/ubuntu:25.04
 
     steps:
       - name: Get current Month
@@ -37,14 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt -y install libjxl-tools plasma-wallpaper-dynamic
-
-      - name: Convert to PNG
-        run: |
-          for wallpaper in *.jxl ; do
-            echo "Processing $wallpaper"
-            djxl "$wallpaper" "${wallpaper%.*}.png"
-          done
+          sudo apt -y install plasma-wallpaper-dynamic kimageformat-plugins
 
       - name: Create manifests
         run: |
@@ -54,10 +48,10 @@ jobs:
             "Meta": [
               {
                 "TimeOfDay": "day",
-                "FileName": "$NMONTH-bluefin-day.png"
+                "FileName": "$NMONTH-bluefin-day.jxl"
               }, {
                 "TimeOfDay": "night",
-                "FileName": "$NMONTH-bluefin-night.png"
+                "FileName": "$NMONTH-bluefin-night.jxl"
               }
             ]
           }
@@ -68,10 +62,10 @@ jobs:
             "Meta": [
               {
                 "TimeOfDay": "day",
-                "FileName": "$SMONTH-bluefin-day.png"
+                "FileName": "$SMONTH-bluefin-day.jxl"
               }, {
                 "TimeOfDay": "night",
-                "FileName": "$SMONTH-bluefin-night.png"
+                "FileName": "$SMONTH-bluefin-night.jxl"
               }
             ]
           }
@@ -79,8 +73,8 @@ jobs:
       
       - name: Encode AVIFs
         run: |
-          kdynamicwallpaperbuilder manifest-north.json --output north.avif
-          kdynamicwallpaperbuilder manifest-south.json --output south.avif
+          kdynamicwallpaperbuilder --speed 8 manifest-north.json --output north.avif
+          kdynamicwallpaperbuilder --speed 8 manifest-south.json --output south.avif
 
       - name: Checksum
         run: |


### PR DESCRIPTION
this uses an ubuntu container that has the needed kimageformats-plugins dependency of plasma-wallpapers-dynamic that allows converting from jxl to avif, cutting out the whole png conversion.
See:
https://github.com/renner0e/bluefin-wallpapers-plasma/actions/runs/18153006064/job/51667150613
https://github.com/renner0e/bluefin-wallpapers-plasma/releases/tag/v2025-10-01

Overall faster action runs by sacrifing negligible disk space savings with the --speed flag